### PR TITLE
fix(rakuyomi): don't treat every library file as a chapter when storage_path is the library folder

### DIFF
--- a/modules/filebrowser/patches/rakuyomi.lua
+++ b/modules/filebrowser/patches/rakuyomi.lua
@@ -228,13 +228,27 @@ local function has_origin_metadata(path)
     return has_origin
 end
 
+-- Rakuyomi's storage_path is user-configurable and may be pointed at the
+-- KOReader library folder itself. In that case every book in the library sits
+-- "inside storage", so path containment proves nothing -- fall back to the
+-- authoritative zip-comment origin check instead.
+local function storage_shadows_library()
+    local ok, paths = pcall(require, "common/paths")
+    local home = ok and type(paths) == "table" and type(paths.getHomeDir) == "function"
+        and paths.getHomeDir() or nil
+    home = normalize_path(home)
+    if not home then return false end
+    return home == get_storage_path()
+end
+
 function M.isChapterFile(path)
     if type(path) ~= "string" then
         return false
     end
 
     local storage = get_storage_path()
-    local in_storage = path_is_inside(path, storage) == true
+    local in_storage = not storage_shadows_library()
+        and path_is_inside(path, storage) == true
     local has_origin = in_storage or has_origin_metadata(path)
     return has_origin
 end


### PR DESCRIPTION
Fixes #519.

`isChapterFile()` treated path containment inside Rakuyomi's `storage_path` as
proof that a file is a manga chapter. When a user points Rakuyomi's download
folder at their KOReader library (`/mnt/us/books`), every EPUB in the library
matches — so `installShowReaderCapture` sets `__ZEN_UI_FORCE_SOURCE_TAB_RESTORE`
on every book open, and Home restores the `manga` tab instead of the configured
default. Reproducible on every book, and it happens even with
`restore_library_view = false` and `return_to_chapter_list_on_exit = false`,
because `force_restore` wins over `restore_enabled` in navbar.lua.

This adds `storage_shadows_library()`: when `storage_path` resolves to the
library home dir itself, containment carries no information, so detection falls
back to `has_origin_metadata()` (the zip-comment `chapter_id`/`manga_id`/
`source_id` check), which is authoritative.

Behaviour is unchanged for a dedicated downloads folder — the common case takes
exactly the same path as before. Only the shadowing case changes, and
`origin_metadata_cache` means the fallback is one read per distinct path.

Two alternatives I ruled out:

- **Gating on a `.cbz` extension.** Rakuyomi supports lnreader sources, which
  produce non-CBZ chapters; this would break detection for them.
- **Clearing the `__ZEN_UI_*` globals in an `else` branch of the `showReader`
  capture.** The Continue handler sets those globals and *then* calls
  `showReader` (navbar.lua:1315-1319), so an unconditional else would wipe them
  immediately and regress the tab restore added in #291. I mentioned this idea
  in the issue before tracing the ordering — it's not safe, so it's not here.

Tested on a Kindle Colorsoft, KOReader v2026.07.1 (kindlehf), ZenOS 3.1.0,
Rakuyomi v1.41.2.